### PR TITLE
[APPS-5] Fixed composer.json content to be indented by 4 spaces.

### DIFF
--- a/src/SprykerSdk/Zed/ComposerReplace/Business/ComposerReplace/Updater/ComposerReplaceUpdater.php
+++ b/src/SprykerSdk/Zed/ComposerReplace/Business/ComposerReplace/Updater/ComposerReplaceUpdater.php
@@ -104,9 +104,7 @@ class ComposerReplaceUpdater implements ComposerReplaceUpdaterInterface
     {
         ksort($composerJsonArray['replace']);
 
-        $encodedJson4Spaces = json_encode($composerJsonArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-        $encodedJson2Spaces = preg_replace('/^(  +?)\\1(?=[^ ])/m', '$1', $encodedJson4Spaces) . "\n";
-
-        file_put_contents($pathToComposerJson, $encodedJson2Spaces);
+        $encodedJson = json_encode($composerJsonArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        file_put_contents($pathToComposerJson, $encodedJson . "\n");
     }
 }


### PR DESCRIPTION
- Developer(s): @pushokwhite

- Ticket: https://spryker.atlassian.net/browse/APPS-5

- Release Group: https://release.spryker.com/release-groups/view/3531

- PR Overview: https://release.spryker.com/release/pull-request-sdk/ComposerReplace/7

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ComposerReplace         | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module ComposerReplace

##### Change log

Fixes

- Fixed generated composer data to be indented by 4 spaces.